### PR TITLE
View the slides in the original dir to facilitate easier debugging and live changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ dist
 index.html
 .remote-assets
 components.d.ts
+.slides_pdf
 
 # nonsense
 desktop.ini

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,4 @@ site_*
 
 gapminder.arrow
 
-**/screencast/style.css
-
-
 .ipynb_checkpoints/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,29 +66,32 @@ line-length = 88
 [tool.ruff.lint]
 select = ["ALL"]
 extend-ignore = [
-    "PLR2004",  # Magic value used in comparison
-    "S101",  # Use of `assert` detected.
-    "ANN",  # Missing type annotations
-    "D100",
-    "T201",
+    "ANN",  # Missing type annotations.
+    "B008", # Do not perform function calls in argument defaults.
     "B018",
-    "TRY003",
-    "PLR0913",
+    "BLE001",
+    "COM812",  # May cause conflict with ruff's formatter.
+    "D100",
+    "D103", # lots of small functions missing docstrings.
     "EM101",
     "FBT001",
-    "N999", # capitalized module name
-    "S602", # `subprocess` call with `shell=True`
-    "S110",
-    "BLE001",
-    "PD901", # `df` used a lot as example variable name
-    "D103", # lots of small functions missing docstrings
+    "FIX002",  # allow TODOs in the code.
     "INP001", # implicit namespace packages; clashes with our pytask examples.
-    "S301",
+    "ISC001",  # May cause conflict with ruff's formatter.
+    "N999", # Capitalized module name.
     "PD010",
     "PD015",
-    "B008", # Do not perform function calls in argument defaults.
-    "PT011", # catching broad exceptions in tests is just fine
-    "PERF401", # use a list comprehension
+    "PD901", # `df` used a lot as example variable name.
+    "PERF401", # use a list comprehension.
+    "PLR0913",
+    "PLR2004",  # Magic value used in comparison.
+    "PT011", # catching broad exceptions in tests is just fine.
+    "S101",  # Use of `assert` detected.
+    "S110",
+    "S301",
+    "S602", # `subprocess` call with `shell=True`.
+    "T201",
+    "TRY003",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/epp_topics/background/file_systems/config.py
+++ b/src/epp_topics/background/file_systems/config.py
@@ -2,9 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/unix_path_mambaforge.png",
-        "screencast/public/windows_path_mambaforge.png",
-    ),
+    "other": (),
     "built": ("background-file_systems.pdf",),
 }

--- a/src/epp_topics/background/file_systems/screencast/slides.md
+++ b/src/epp_topics/background/file_systems/screencast/slides.md
@@ -91,9 +91,10 @@ graph LR
 ### GUI representation
 
 <center>
-<img src="unix_path_mambaforge.png" width=450>
+<img src="/unix_path_mambaforge.png" width=450>
 </center>
 
+</div>
 </div>
 
 <div v-click>
@@ -177,9 +178,10 @@ graph LR
 ### GUI representation
 
 <center>
-<img src="windows_path_mambaforge.png" width=250>
+<img src="/windows_path_mambaforge.png" width=250>
 </center>
 
+</div>
 </div>
 
 <div v-click>

--- a/src/epp_topics/background/file_systems/screencast/style.css
+++ b/src/epp_topics/background/file_systems/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/background/floats/config.py
+++ b/src/epp_topics/background/floats/config.py
@@ -2,12 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/vt100.jpg",
-        "screencast/public/bell-labs.jpg",
-        "screencast/public/linus.jpg",
-        "screencast/public/stevejobs-next.jpg",
-        "screencast/public/windows-1-desktop.jpg",
-    ),
+    "other": (),
     "built": ("background-floats.pdf",),
 }

--- a/src/epp_topics/background/floats/screencast/slides.md
+++ b/src/epp_topics/background/floats/screencast/slides.md
@@ -42,7 +42,7 @@ layout: two-cols
 ::right::
 
 <center>
-<img src="vt100.jpg" width=350>
+<img src="/vt100.jpg" width=350>
 </center>
 
 <br/>
@@ -63,7 +63,7 @@ layout: two-cols
 ::right::
 
 <center>
-<img src="bell-labs.jpg" width=350>
+<img src="/bell-labs.jpg" width=350>
 </center>
 
 ---
@@ -80,7 +80,7 @@ layout: two-cols
 ::right::
 
 <center>
-<img src="linus.jpg" width=350>
+<img src="/linus.jpg" width=350>
 </center>
 
 
@@ -100,7 +100,7 @@ layout: two-cols
 ::right::
 
 <center>
-<img src="stevejobs-next.jpg" width=350>
+<img src="/stevejobs-next.jpg" width=350>
 </center>
 
 
@@ -126,7 +126,7 @@ layout: two-cols
 ::right::
 
 <center>
-<img src="windows-1-desktop.jpg" width=350>
+<img src="/windows-1-desktop.jpg" width=350>
 </center>
 
 

--- a/src/epp_topics/background/floats/screencast/style.css
+++ b/src/epp_topics/background/floats/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/background/graphs/screencast/style.css
+++ b/src/epp_topics/background/graphs/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/background/os_history/config.py
+++ b/src/epp_topics/background/os_history/config.py
@@ -2,12 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/vt100.jpg",
-        "screencast/public/bell-labs.jpg",
-        "screencast/public/linus.jpg",
-        "screencast/public/stevejobs-next.jpg",
-        "screencast/public/windows-1-desktop.jpg",
-    ),
+    "other": (),
     "built": ("background-os_history.pdf",),
 }

--- a/src/epp_topics/background/os_history/screencast/slides.md
+++ b/src/epp_topics/background/os_history/screencast/slides.md
@@ -47,7 +47,7 @@ Janoś Gabler and Hans-Martin von Gaudecker
 <div>
 
 <center>
-<img src="vt100.jpg" width=350>
+<img src="/vt100.jpg" width=350>
 </center>
 
 <br/>
@@ -73,7 +73,7 @@ Janoś Gabler and Hans-Martin von Gaudecker
 <div>
 
 <center>
-<img src="bell-labs.jpg" width=350>
+<img src="/bell-labs.jpg" width=350>
 </center>
 
 </div>
@@ -95,7 +95,7 @@ Janoś Gabler and Hans-Martin von Gaudecker
 <div>
 
 <center>
-<img src="linus.jpg" width=350>
+<img src="/linus.jpg" width=350>
 </center>
 
 </div>
@@ -120,7 +120,7 @@ Janoś Gabler and Hans-Martin von Gaudecker
 <div>
 
 <center>
-<img src="stevejobs-next.jpg" width=300>
+<img src="/stevejobs-next.jpg" width=300>
 </center>
 
 </div>
@@ -151,7 +151,7 @@ Janoś Gabler and Hans-Martin von Gaudecker
 <div>
 
 <center>
-<img src="windows-1-desktop.jpg" width=350>
+<img src="/windows-1-desktop.jpg" width=350>
 </center>
 
 </div>

--- a/src/epp_topics/background/os_history/screencast/style.css
+++ b/src/epp_topics/background/os_history/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/chapter_template/subchapter_1/screencast/style.css
+++ b/src/epp_topics/chapter_template/subchapter_1/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/config.py
+++ b/src/epp_topics/config.py
@@ -27,6 +27,7 @@ CHAPTER_NAMES = [
 
 
 SRC = Path(__file__).parent.resolve()
+SLIDES_PDF_DIR = SRC.parent.parent / ".slides_pdf"
 SITE_SOURCE_DIR = SRC.parent.parent / "site_source"
 SITE_DIR = SRC.parent.parent.parent / "effective-programming-practices"
 

--- a/src/epp_topics/debugging/avoiding_debugging/screencast/style.css
+++ b/src/epp_topics/debugging/avoiding_debugging/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/debugging/debugging_intro/screencast/style.css
+++ b/src/epp_topics/debugging/debugging_intro/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/debugging/debugging_psychology/screencast/style.css
+++ b/src/epp_topics/debugging/debugging_psychology/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/debugging/debugging_strategies/screencast/style.css
+++ b/src/epp_topics/debugging/debugging_strategies/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/debugging/gathering_data/screencast/style.css
+++ b/src/epp_topics/debugging/gathering_data/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/debugging/pdbp/screencast/style.css
+++ b/src/epp_topics/debugging/pdbp/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/git/introduction/screencast/style.css
+++ b/src/epp_topics/git/introduction/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/git/pre_commits/config.py
+++ b/src/epp_topics/git/pre_commits/config.py
@@ -2,10 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/git_status.png",
-        "screencast/public/first_commit.png",
-        "screencast/public/second_commit.png",
-    ),
+    "other": (),
     "built": ("git-pre_commits.pdf",),
 }

--- a/src/epp_topics/git/pre_commits/screencast/slides.md
+++ b/src/epp_topics/git/pre_commits/screencast/slides.md
@@ -120,17 +120,17 @@ def clean_agreement_scale(sr):
 
 # Git status
 
-<img src="git_status.png" class="rounded" width="700"/>
+<img src="/git_status.png" class="rounded" width="700"/>
 
 ---
 
 # First commit fails
 
-<img src="first_commit.png" class="rounded" width="700"/>
+<img src="/first_commit.png" class="rounded" width="700"/>
 
 
 ---
 
 # Second commit works
 
-<img src="second_commit.png" class="rounded" width="700"/>
+<img src="/second_commit.png" class="rounded" width="700"/>

--- a/src/epp_topics/git/pre_commits/screencast/style.css
+++ b/src/epp_topics/git/pre_commits/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/columns_and_indices/screencast/style.css
+++ b/src/epp_topics/pandas/columns_and_indices/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/creating_variables/screencast/style.css
+++ b/src/epp_topics/pandas/creating_variables/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/dataframes_and_series/screencast/style.css
+++ b/src/epp_topics/pandas/dataframes_and_series/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/datatypes/screencast/style.css
+++ b/src/epp_topics/pandas/datatypes/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/functional/screencast/style.css
+++ b/src/epp_topics/pandas/functional/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/inspecting_and_summarizing/screencast/public/lineplot.png
+++ b/src/epp_topics/pandas/inspecting_and_summarizing/screencast/public/lineplot.png
@@ -1,0 +1,1 @@
+../../../../../../site_source/pandas/inspecting_and_summarizing/lineplot.png

--- a/src/epp_topics/pandas/inspecting_and_summarizing/screencast/public/scatterplot.png
+++ b/src/epp_topics/pandas/inspecting_and_summarizing/screencast/public/scatterplot.png
@@ -1,0 +1,1 @@
+../../../../../../site_source/pandas/inspecting_and_summarizing/scatterplot.png

--- a/src/epp_topics/pandas/inspecting_and_summarizing/screencast/slides.md
+++ b/src/epp_topics/pandas/inspecting_and_summarizing/screencast/slides.md
@@ -332,7 +332,7 @@ year
 >>> pd.options.plotting.backend = "plotly"
 >>> df.groupby("year")["life_exp"].mean().plot()
 ```
-<img src="lineplot.png" class="rounded" width="400"/>
+<img src="/lineplot.png" class="rounded" width="400"/>
 
 </div>
 <div>
@@ -356,7 +356,7 @@ year
 >>> df.plot.scatter(x="year", y="life_exp",
                     color="country")
 ```
-<img src="scatterplot.png" class="rounded" width="400"/>
+<img src="/scatterplot.png" class="rounded" width="400"/>
 
 </div>
 <div>

--- a/src/epp_topics/pandas/inspecting_and_summarizing/screencast/style.css
+++ b/src/epp_topics/pandas/inspecting_and_summarizing/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/inspecting_and_summarizing/screencast/task_create_plot.py
+++ b/src/epp_topics/pandas/inspecting_and_summarizing/screencast/task_create_plot.py
@@ -6,22 +6,10 @@ from epp_topics.config import SITE_SOURCE_DIR
 pd.options.plotting.backend = "plotly"
 
 
-LINEPLOT = (
-    SITE_SOURCE_DIR
-    / "pandas"
-    / "inspecting_and_summarizing"
-    / "screencast"
-    / "public"
-    / "lineplot.png"
-)
+LINEPLOT = SITE_SOURCE_DIR / "pandas" / "inspecting_and_summarizing" / "lineplot.png"
 
 SCATTERPLOT = (
-    SITE_SOURCE_DIR
-    / "pandas"
-    / "inspecting_and_summarizing"
-    / "screencast"
-    / "public"
-    / "scatterplot.png"
+    SITE_SOURCE_DIR / "pandas" / "inspecting_and_summarizing" / "scatterplot.png"
 )
 
 

--- a/src/epp_topics/pandas/loading_and_saving/screencast/style.css
+++ b/src/epp_topics/pandas/loading_and_saving/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/merging/screencast/style.css
+++ b/src/epp_topics/pandas/merging/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/rules/screencast/style.css
+++ b/src/epp_topics/pandas/rules/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/selection/screencast/style.css
+++ b/src/epp_topics/pandas/selection/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/pandas/what_is_pandas/screencast/style.css
+++ b/src/epp_topics/pandas/what_is_pandas/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/plotting/goals_workflow/screencast/style.css
+++ b/src/epp_topics/plotting/goals_workflow/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/plotting/graph_objects/screencast/style.css
+++ b/src/epp_topics/plotting/graph_objects/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/plotting/quick_plots/screencast/style.css
+++ b/src/epp_topics/plotting/quick_plots/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/plotting/tweak_px/screencast/style.css
+++ b/src/epp_topics/plotting/tweak_px/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/plotting/what_to_plot/screencast/style.css
+++ b/src/epp_topics/plotting/what_to_plot/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/plotting/why_plotly_prerequisites/screencast/style.css
+++ b/src/epp_topics/plotting/why_plotly_prerequisites/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/directory_structure/screencast/style.css
+++ b/src/epp_topics/projects/directory_structure/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/paths/screencast/style.css
+++ b/src/epp_topics/projects/paths/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/pytask_docs/screencast/style.css
+++ b/src/epp_topics/projects/pytask_docs/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/reproducibility/screencast/style.css
+++ b/src/epp_topics/projects/reproducibility/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/reusing_pytask_functions/config.py
+++ b/src/epp_topics/projects/reusing_pytask_functions/config.py
@@ -2,10 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/collect_nodes.png",
-        "screencast/public/run_1.png",
-        "screencast/public/run_2.png",
-    ),
+    "other": (),
     "built": ("projects-reusing_pytask_functions.pdf",),
 }

--- a/src/epp_topics/projects/reusing_pytask_functions/screencast/slides.md
+++ b/src/epp_topics/projects/reusing_pytask_functions/screencast/slides.md
@@ -132,7 +132,7 @@ for region in ("Asia", "Europe"):
 </div>
 <div>
 
-<img src="collect_nodes.png" class="rounded" width="350"/>
+<img src="/collect_nodes.png" class="rounded" width="350"/>
 
 
 </div>
@@ -143,13 +143,13 @@ for region in ("Asia", "Europe"):
 
 # Run pytask
 
-<img src="run_1.png" class="rounded" width="555"/>
+<img src="/run_1.png" class="rounded" width="555"/>
 
 ---
 
 # Delete plot and run again
 
-<img src="run_2.png" class="rounded" width="555"/>
+<img src="/run_2.png" class="rounded" width="555"/>
 
 
 ---

--- a/src/epp_topics/projects/reusing_pytask_functions/screencast/style.css
+++ b/src/epp_topics/projects/reusing_pytask_functions/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/setup/screencast/style.css
+++ b/src/epp_topics/projects/setup/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/what_are_templates/screencast/style.css
+++ b/src/epp_topics/projects/what_are_templates/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/what_does_pytask_do/config.py
+++ b/src/epp_topics/projects/what_does_pytask_do/config.py
@@ -4,10 +4,6 @@ SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
     "other": (
         # "existing figures etc.",
-        "screencast/public/collect.png",
-        "screencast/public/collect_nodes.png",
-        "screencast/public/run_1.png",
-        "screencast/public/run_2_after_deleting_plot.png",
         "screencast/public/run_3_after_deleting_data.png",
     ),
     "built": ("projects-what_does_pytask_do.pdf",),

--- a/src/epp_topics/projects/what_does_pytask_do/config.py
+++ b/src/epp_topics/projects/what_does_pytask_do/config.py
@@ -2,9 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        # "existing figures etc.",
-        "screencast/public/run_3_after_deleting_data.png",
-    ),
+    "other": (),
     "built": ("projects-what_does_pytask_do.pdf",),
 }

--- a/src/epp_topics/projects/what_does_pytask_do/screencast/slides.md
+++ b/src/epp_topics/projects/what_does_pytask_do/screencast/slides.md
@@ -79,7 +79,7 @@ graph LR
 </div>
 <div>
 
-<img src="collect.png" class="rounded" width="350"/>
+<img src="/collect.png" class="rounded" width="350"/>
 
 
 </div>
@@ -103,7 +103,7 @@ structure (topological sort)
 </div>
 <div>
 
-<img src="collect_nodes.png" class="rounded" width="350"/>
+<img src="/collect_nodes.png" class="rounded" width="350"/>
 
 
 </div>
@@ -131,7 +131,7 @@ graph TD
 </div>
 <div>
 
-<img src="collect_nodes.png" class="rounded" width="350"/>
+<img src="/collect_nodes.png" class="rounded" width="350"/>
 
 </div>
 </div>
@@ -152,16 +152,16 @@ graph TD
 
 # Run for the first time
 
-<img src="run_1.png" class="rounded" width="700"/>
+<img src="/run_1.png" class="rounded" width="700"/>
 
 ---
 
 # Delete plot and run again
 
-<img src="run_2_after_deleting_plot.png" class="rounded" width="700"/>
+<img src="/run_2_after_deleting_plot.png" class="rounded" width="700"/>
 
 ---
 
 # Delete cleaned data and run again
 
-<img src="run_3_after_deleting_data.png" class="rounded" width="700"/>
+<img src="/run_3_after_deleting_data.png" class="rounded" width="700"/>

--- a/src/epp_topics/projects/what_does_pytask_do/screencast/style.css
+++ b/src/epp_topics/projects/what_does_pytask_do/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/writing_pytasks_multiple_outputs/config.py
+++ b/src/epp_topics/projects/writing_pytasks_multiple_outputs/config.py
@@ -2,9 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/collect_nodes.png",
-        "screencast/public/run_1.png",
-    ),
+    "other": (),
     "built": ("projects-writing_pytasks_multiple_outputs.pdf",),
 }

--- a/src/epp_topics/projects/writing_pytasks_multiple_outputs/screencast/slides.md
+++ b/src/epp_topics/projects/writing_pytasks_multiple_outputs/screencast/slides.md
@@ -122,7 +122,7 @@ def task_plot_life_expectancy(
 </div>
 <div>
 
-<img src="collect_nodes.png" class="rounded" width="350"/>
+<img src="/collect_nodes.png" class="rounded" width="350"/>
 
 
 </div>
@@ -133,7 +133,7 @@ def task_plot_life_expectancy(
 
 # Run pytask
 
-<img src="run_1.png" class="rounded" width="555"/>
+<img src="/run_1.png" class="rounded" width="555"/>
 
 ---
 

--- a/src/epp_topics/projects/writing_pytasks_multiple_outputs/screencast/style.css
+++ b/src/epp_topics/projects/writing_pytasks_multiple_outputs/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/projects/writing_simple_pytasks/config.py
+++ b/src/epp_topics/projects/writing_simple_pytasks/config.py
@@ -2,6 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": ("screencast/public/run_1.png",),
+    "other": (),
     "built": ("projects-writing_simple_pytasks.pdf",),
 }

--- a/src/epp_topics/projects/writing_simple_pytasks/screencast/slides.md
+++ b/src/epp_topics/projects/writing_simple_pytasks/screencast/slides.md
@@ -117,7 +117,7 @@ def _plot_life_expectancy(df):
 
 # Run pytask
 
-<img src="run_1.png" class="rounded" width="700"/>
+<img src="/run_1.png" class="rounded" width="700"/>
 
 ---
 

--- a/src/epp_topics/projects/writing_simple_pytasks/screencast/style.css
+++ b/src/epp_topics/projects/writing_simple_pytasks/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/assignment_and_scalar_types/screencast/style.css
+++ b/src/epp_topics/python_basics/assignment_and_scalar_types/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/comprehensions/screencast/style.css
+++ b/src/epp_topics/python_basics/comprehensions/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/dicts/screencast/style.css
+++ b/src/epp_topics/python_basics/dicts/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/for_loops/screencast/style.css
+++ b/src/epp_topics/python_basics/for_loops/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/functions_basics/config.py
+++ b/src/epp_topics/python_basics/functions_basics/config.py
@@ -2,6 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": ("screencast/public/function_anatomy.png",),
+    "other": (),
     "built": ("python_basics-functions_basics.pdf",),
 }

--- a/src/epp_topics/python_basics/functions_basics/screencast/style.css
+++ b/src/epp_topics/python_basics/functions_basics/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/functions_principles/screencast/style.css
+++ b/src/epp_topics/python_basics/functions_principles/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/if_conditions/screencast/style.css
+++ b/src/epp_topics/python_basics/if_conditions/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/importing/screencast/style.css
+++ b/src/epp_topics/python_basics/importing/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/lists_tuples_sets/screencast/style.css
+++ b/src/epp_topics/python_basics/lists_tuples_sets/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/pathlib/screencast/style.css
+++ b/src/epp_topics/python_basics/pathlib/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/strings/screencast/style.css
+++ b/src/epp_topics/python_basics/strings/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_basics/tracebacks/config.py
+++ b/src/epp_topics/python_basics/tracebacks/config.py
@@ -2,6 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": ("screencast/public/simple_traceback.png",),
+    "other": (),
     "built": ("python_basics-tracebacks.pdf",),
 }

--- a/src/epp_topics/python_basics/tracebacks/screencast/style.css
+++ b/src/epp_topics/python_basics/tracebacks/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_installation_execution/environments/screencast/style.css
+++ b/src/epp_topics/python_installation_execution/environments/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_installation_execution/executing_notebook_browser/config.py
+++ b/src/epp_topics/python_installation_execution/executing_notebook_browser/config.py
@@ -2,12 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/activate_and_info.png",
-        "screencast/public/blocked_terminal.png",
-        "screencast/public/folder.png",
-        "screencast/public/notebook.png",
-        "screencast/public/starting_page.png",
-    ),
+    "other": (),
     "built": ("python_installation_execution-executing_notebook_browser.pdf",),
 }

--- a/src/epp_topics/python_installation_execution/executing_notebook_browser/screencast/slides.md
+++ b/src/epp_topics/python_installation_execution/executing_notebook_browser/screencast/slides.md
@@ -45,7 +45,7 @@ Janoś Gabler and Hans-Martin von Gaudecker
 
 # 0. Activate and Info
 
-<img src="activate_and_info.png" class="rounded" width="600"/>
+<img src="/activate_and_info.png" class="rounded" width="600"/>
 
 ---
 
@@ -73,25 +73,25 @@ graph LR
 
 # 1. Start Notebook
 
-<img src="blocked_terminal.png" class="rounded" width="600"/>
+<img src="/blocked_terminal.png" class="rounded" width="600"/>
 
 
 ---
 
 # 2. Landing Page
 
-<img src="starting_page.png" class="rounded" width="600"/>
+<img src="/starting_page.png" class="rounded" width="600"/>
 
 
 ---
 
 # 3. Click on Folder
 
-<img src="folder.png" class="rounded" width="600"/>
+<img src="/folder.png" class="rounded" width="600"/>
 
 
 ---
 
 # 4. Work in the Notebook
 
-<img src="notebook.png" class="rounded" width="600"/>
+<img src="/notebook.png" class="rounded" width="600"/>

--- a/src/epp_topics/python_installation_execution/executing_notebook_browser/screencast/style.css
+++ b/src/epp_topics/python_installation_execution/executing_notebook_browser/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_installation_execution/executing_notebook_vscode/config.py
+++ b/src/epp_topics/python_installation_execution/executing_notebook_vscode/config.py
@@ -2,13 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        # "existing figures etc.",
-        "screencast/public/select_epp.png",
-        "screencast/public/click_on_python_environments.png",
-        "screencast/public/click_on_other.png",
-        "screencast/public/command_select_interpreter.png",
-        "screencast/public/ipynb_file.png",
-    ),
+    "other": (),
     "built": ("python_installation_execution-executing_notebook_vscode.pdf",),
 }

--- a/src/epp_topics/python_installation_execution/executing_notebook_vscode/screencast/slides.md
+++ b/src/epp_topics/python_installation_execution/executing_notebook_vscode/screencast/slides.md
@@ -64,34 +64,34 @@ graph LR
 
 # 1. Open the file
 
-<img src="ipynb_file.png" class="rounded" width="600"/>
+<img src="/ipynb_file.png" class="rounded" width="600"/>
 
 
 ---
 
 # 2. Command palette (ctrl + shift + p)
 
-<img src="command_select_interpreter.png" class="rounded" width="600"/>
+<img src="/command_select_interpreter.png" class="rounded" width="600"/>
 
 
 ---
 
 # 3. Click on "Select another kernel"
 
-<img src="click_on_other.png" class="rounded" width="600"/>
+<img src="/click_on_other.png" class="rounded" width="600"/>
 
 
 ---
 
 # 4. Click on "Python environments"
 
-<img src="click_on_python_environments.png" class="rounded" width="600"/>
+<img src="/click_on_python_environments.png" class="rounded" width="600"/>
 
 ---
 
 # 5. Select the epp environment
 
-<img src="select_epp.png" class="rounded" width="600"/>
+<img src="/select_epp.png" class="rounded" width="600"/>
 
 ---
 class: text-xs

--- a/src/epp_topics/python_installation_execution/executing_notebook_vscode/screencast/style.css
+++ b/src/epp_topics/python_installation_execution/executing_notebook_vscode/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_installation_execution/executing_py_shell/config.py
+++ b/src/epp_topics/python_installation_execution/executing_py_shell/config.py
@@ -2,10 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        # "existing figures etc.",
-        "screencast/public/activate_and_info.png",
-        "screencast/public/run.png",
-    ),
+    "other": (),
     "built": ("python_installation_execution-executing_py_shell.pdf",),
 }

--- a/src/epp_topics/python_installation_execution/executing_py_shell/screencast/slides.md
+++ b/src/epp_topics/python_installation_execution/executing_py_shell/screencast/slides.md
@@ -46,7 +46,7 @@ Janoś Gabler and Hans-Martin von Gaudecker
 
 # 0: Activate and Info
 
-<img src="activate_and_info.png" class="rounded" width="600"/>
+<img src="/activate_and_info.png" class="rounded" width="600"/>
 
 
 ---
@@ -76,4 +76,4 @@ graph LR
 # 1: Execute
 
 
-<img src="run.png" class="rounded" width="600"/>
+<img src="/run.png" class="rounded" width="600"/>

--- a/src/epp_topics/python_installation_execution/executing_py_shell/screencast/style.css
+++ b/src/epp_topics/python_installation_execution/executing_py_shell/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_installation_execution/executing_py_vscode/config.py
+++ b/src/epp_topics/python_installation_execution/executing_py_vscode/config.py
@@ -2,12 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        # "existing figures etc.",
-        "screencast/public/click_run.png",
-        "screencast/public/selecting_epp_env.png",
-        "screencast/public/command_select_interpreter.png",
-        "screencast/public/py_file.png",
-    ),
+    "other": (),
     "built": ("python_installation_execution-executing_py_vscode.pdf",),
 }

--- a/src/epp_topics/python_installation_execution/executing_py_vscode/screencast/slides.md
+++ b/src/epp_topics/python_installation_execution/executing_py_vscode/screencast/slides.md
@@ -62,25 +62,25 @@ graph LR
 
 # 1. Open the file
 
-<img src="py_file.png" class="rounded" width="600"/>
+<img src="/py_file.png" class="rounded" width="600"/>
 
 
 ---
 
 # 2. Command palette (ctrl + shift + p)
 
-<img src="command_select_interpreter.png" class="rounded" width="600"/>
+<img src="/command_select_interpreter.png" class="rounded" width="600"/>
 
 
 ---
 
 # 3. Select the epp environment
 
-<img src="selecting_epp_env.png" class="rounded" width="600"/>
+<img src="/selecting_epp_env.png" class="rounded" width="600"/>
 
 
 ---
 
 # 4. Run the file
 
-<img src="click_run.png" class="rounded" width="600"/>
+<img src="/click_run.png" class="rounded" width="600"/>

--- a/src/epp_topics/python_installation_execution/executing_py_vscode/screencast/style.css
+++ b/src/epp_topics/python_installation_execution/executing_py_vscode/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_installation_execution/executing_pytask/config.py
+++ b/src/epp_topics/python_installation_execution/executing_pytask/config.py
@@ -2,11 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        # "existing figures etc.",
-        "screencast/public/activate_and_info.png",
-        "screencast/public/run_1.png",
-        "screencast/public/run_2.png",
-    ),
+    "other": (),
     "built": ("python_installation_execution-executing_pytask.pdf",),
 }

--- a/src/epp_topics/python_installation_execution/executing_pytask/screencast/slides.md
+++ b/src/epp_topics/python_installation_execution/executing_pytask/screencast/slides.md
@@ -46,7 +46,7 @@ Janoś Gabler and Hans-Martin von Gaudecker
 
 # 0: Activate and Info
 
-<img src="activate_and_info.png" class="rounded" width="600"/>
+<img src="/activate_and_info.png" class="rounded" width="600"/>
 
 ---
 
@@ -81,11 +81,11 @@ graph LR
 
 # 1: Execute
 
-<img src="run_1.png" class="rounded" width="600"/>
+<img src="/run_1.png" class="rounded" width="600"/>
 
 
 ---
 
 # 1: Execute again
 
-<img src="run_2.png" class="rounded" width="600"/>
+<img src="/run_2.png" class="rounded" width="600"/>

--- a/src/epp_topics/python_installation_execution/executing_pytask/screencast/style.css
+++ b/src/epp_topics/python_installation_execution/executing_pytask/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/python_installation_execution/executing_pytest/config.py
+++ b/src/epp_topics/python_installation_execution/executing_pytest/config.py
@@ -2,9 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/activate_and_info.png",
-        "screencast/public/run.png",
-    ),
+    "other": (),
     "built": ("python_installation_execution-executing_pytest.pdf",),
 }

--- a/src/epp_topics/python_installation_execution/executing_pytest/screencast/slides.md
+++ b/src/epp_topics/python_installation_execution/executing_pytest/screencast/slides.md
@@ -46,7 +46,7 @@ Janoś Gabler and Hans-Martin von Gaudecker
 
 # 0: Activate and Info
 
-<img src="activate_and_info.png" class="rounded" width="600"/>
+<img src="/activate_and_info.png" class="rounded" width="600"/>
 
 ---
 
@@ -82,4 +82,4 @@ graph LR
 
 # 1: Execute
 
-<img src="run.png" class="rounded" width="600"/>
+<img src="/run.png" class="rounded" width="600"/>

--- a/src/epp_topics/python_installation_execution/executing_pytest/screencast/style.css
+++ b/src/epp_topics/python_installation_execution/executing_pytest/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/broadcasting/screencast/style.css
+++ b/src/epp_topics/scientific_computing/broadcasting/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/calculations_between_arrays/screencast/style.css
+++ b/src/epp_topics/scientific_computing/calculations_between_arrays/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/calculations_on_arrays/screencast/style.css
+++ b/src/epp_topics/scientific_computing/calculations_on_arrays/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/creating_arrays/screencast/style.css
+++ b/src/epp_topics/scientific_computing/creating_arrays/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/indexing/screencast/style.css
+++ b/src/epp_topics/scientific_computing/indexing/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/optimization_algorithms/screencast/style.css
+++ b/src/epp_topics/scientific_computing/optimization_algorithms/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/optimization_histories/config.py
+++ b/src/epp_topics/scientific_computing/optimization_histories/config.py
@@ -2,12 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        # "existing figures etc.",
-        "screencast/public/criterion_plot.png",
-        "screencast/public/criterion_plot_max_evaluations.png",
-        "screencast/public/criterion_plot_monotone.png",
-        "screencast/public/multi_optimization_criterion_plot.svg",
-    ),
+    "other": (),
     "built": ("scientific_computing-optimization_histories.pdf",),
 }

--- a/src/epp_topics/scientific_computing/optimization_histories/screencast/slides.md
+++ b/src/epp_topics/scientific_computing/optimization_histories/screencast/slides.md
@@ -66,7 +66,7 @@ em.criterion_plot(res)
 <div class="grid grid-cols-2 gap-12">
 <div>
 
-<img src="criterion_plot.png" alt="criterion" width="500" style="display: block;"/>
+<img src="/criterion_plot.png" alt="criterion" width="500" style="display: block;"/>
 
 </div>
 <div>
@@ -92,7 +92,7 @@ em.criterion_plot(res, monotone=True)
 
 <div class="grid grid-cols-2 gap-4">
 <div>
-<img src="criterion_plot_monotone.png" alt="criterion" width="500"
+<img src="/criterion_plot_monotone.png" alt="criterion" width="500"
 style="display: block;"/>
 
 </div>
@@ -117,7 +117,7 @@ em.criterion_plot(res, max_evaluations=300)
 
 <div class="grid grid-cols-2 gap-4">
 <div>
-<img src="criterion_plot_max_evaluations.png" alt="criterion" width="500"
+<img src="/criterion_plot_max_evaluations.png" alt="criterion" width="500"
 style="display: block;"/>
 
 </div>
@@ -162,7 +162,7 @@ em.criterion_plot(results, max_evaluations=200)
 </div>
 <div>
 
-<img src="multi_optimization_criterion_plot.svg" class="rounded" width="300"/>
+<img src="/multi_optimization_criterion_plot.svg" class="rounded" width="300"/>
 
 </div>
 </div>

--- a/src/epp_topics/scientific_computing/optimization_histories/screencast/style.css
+++ b/src/epp_topics/scientific_computing/optimization_histories/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/optimization_intro/config.py
+++ b/src/epp_topics/scientific_computing/optimization_intro/config.py
@@ -2,9 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        # "existing figures etc.",
-        "screencast/public/sphere.png",
-    ),
+    "other": (),
     "built": ("scientific_computing-optimization_intro.pdf",),
 }

--- a/src/epp_topics/scientific_computing/optimization_intro/screencast/style.css
+++ b/src/epp_topics/scientific_computing/optimization_intro/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/optimization_mechanics/screencast/style.css
+++ b/src/epp_topics/scientific_computing/optimization_mechanics/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/randomness/screencast/style.css
+++ b/src/epp_topics/scientific_computing/randomness/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/speedup_intro/screencast/style.css
+++ b/src/epp_topics/scientific_computing/speedup_intro/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/speedup_line_profile/screencast/style.css
+++ b/src/epp_topics/scientific_computing/speedup_line_profile/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/speedup_measuring_time/screencast/style.css
+++ b/src/epp_topics/scientific_computing/speedup_measuring_time/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/speedup_numba/screencast/style.css
+++ b/src/epp_topics/scientific_computing/speedup_numba/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/speedup_numpy/screencast/style.css
+++ b/src/epp_topics/scientific_computing/speedup_numpy/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/speedup_snakeviz/screencast/style.css
+++ b/src/epp_topics/scientific_computing/speedup_snakeviz/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/scientific_computing/what_is_numpy/screencast/style.css
+++ b/src/epp_topics/scientific_computing/what_is_numpy/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/deciding_containers/screencast/style.css
+++ b/src/epp_topics/software_engineering/deciding_containers/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/defining_containers/screencast/style.css
+++ b/src/epp_topics/software_engineering/defining_containers/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/error_handling_intro/screencast/style.css
+++ b/src/epp_topics/software_engineering/error_handling_intro/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/idea_of_testing/screencast/style.css
+++ b/src/epp_topics/software_engineering/idea_of_testing/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/naming/screencast/style.css
+++ b/src/epp_topics/software_engineering/naming/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/partial/screencast/style.css
+++ b/src/epp_topics/software_engineering/partial/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/pure_functions/screencast/style.css
+++ b/src/epp_topics/software_engineering/pure_functions/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/pytest_error_handling/config.py
+++ b/src/epp_topics/software_engineering/pytest_error_handling/config.py
@@ -2,9 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/run_failed.png",
-        "screencast/public/run_fixed.png",
-    ),
+    "other": (),
     "built": ("software_engineering-pytest_error_handling.pdf",),
 }

--- a/src/epp_topics/software_engineering/pytest_error_handling/screencast/slides.md
+++ b/src/epp_topics/software_engineering/pytest_error_handling/screencast/slides.md
@@ -207,7 +207,7 @@ def test_clean_agreement_scale_invalid_data():
 
 # Run pytest
 
-<img src="run_failed.png" class="rounded" width="550"/>
+<img src="/run_failed.png" class="rounded" width="550"/>
 
 ---
 
@@ -239,4 +239,4 @@ def _clean_agreement_scale(sr):
 
 # Run pytest, again
 
-<img src="run_fixed.png" class="rounded" width="550"/>
+<img src="/run_fixed.png" class="rounded" width="550"/>

--- a/src/epp_topics/software_engineering/pytest_error_handling/screencast/style.css
+++ b/src/epp_topics/software_engineering/pytest_error_handling/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/raising_errors/screencast/style.css
+++ b/src/epp_topics/software_engineering/raising_errors/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/reuse_test_code/config.py
+++ b/src/epp_topics/software_engineering/reuse_test_code/config.py
@@ -2,9 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/run_parametrized.png",
-        "screencast/public/run_fail_for_valid_element.png",
-    ),
+    "other": (),
     "built": ("software_engineering-reuse_test_code.pdf",),
 }

--- a/src/epp_topics/software_engineering/reuse_test_code/screencast/slides.md
+++ b/src/epp_topics/software_engineering/reuse_test_code/screencast/slides.md
@@ -69,7 +69,7 @@ def test_clean_agreement_scale_invalid_data(invalid_input):
 
 # One test function, two tests
 
-<img src="run_parametrized.png" class="rounded" width="650"/>
+<img src="/run_parametrized.png" class="rounded" width="650"/>
 
 
 ---
@@ -77,4 +77,4 @@ def test_clean_agreement_scale_invalid_data(invalid_input):
 # Countercheck fails as it is supposed to
 
 
-<img src="run_fail_for_valid_element.png" class="rounded" width="650"/>
+<img src="/run_fail_for_valid_element.png" class="rounded" width="650"/>

--- a/src/epp_topics/software_engineering/reuse_test_code/screencast/style.css
+++ b/src/epp_topics/software_engineering/reuse_test_code/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/style_guides/screencast/style.css
+++ b/src/epp_topics/software_engineering/style_guides/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/what_and_how_to_test/screencast/style.css
+++ b/src/epp_topics/software_engineering/what_and_how_to_test/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/what_does_pytest_do/config.py
+++ b/src/epp_topics/software_engineering/what_does_pytest_do/config.py
@@ -2,12 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": (
-        "screencast/public/collect_only.png",
-        "screencast/public/run.png",
-        "screencast/public/run_verbose.png",
-        "screencast/public/run_failed.png",
-        "screencast/public/run_pdb.png",
-    ),
+    "other": (),
     "built": ("software_engineering-what_does_pytest_do.pdf",),
 }

--- a/src/epp_topics/software_engineering/what_does_pytest_do/screencast/slides.md
+++ b/src/epp_topics/software_engineering/what_does_pytest_do/screencast/slides.md
@@ -182,7 +182,7 @@ def _clean_favorite_language(sr):
 </div>
 <div class="col-span-3">
 
-<img src="collect_only.png" class="rounded" width="500"/>
+<img src="/collect_only.png" class="rounded" width="500"/>
 
 
 </div>
@@ -202,7 +202,7 @@ def _clean_favorite_language(sr):
 </div>
 <div class="col-span-3">
 
-<img src="run.png" class="rounded" width="500"/>
+<img src="/run.png" class="rounded" width="500"/>
 
 </div>
 </div>
@@ -221,7 +221,7 @@ def _clean_favorite_language(sr):
 </div>
 <div class="col-span-3">
 
-<img src="run_verbose.png" class="rounded" width="500"/>
+<img src="/run_verbose.png" class="rounded" width="500"/>
 
 </div>
 </div>
@@ -230,10 +230,10 @@ def _clean_favorite_language(sr):
 
 # Step 3: Inspect failures
 
-<img src="run_failed.png" class="rounded" width="600"/>
+<img src="/run_failed.png" class="rounded" width="600"/>
 
 ---
 
 # Step 3: Inspect failures with pdb
 
-<img src="run_pdb.png" class="rounded" width="600"/>
+<img src="/run_pdb.png" class="rounded" width="600"/>

--- a/src/epp_topics/software_engineering/what_does_pytest_do/screencast/style.css
+++ b/src/epp_topics/software_engineering/what_does_pytest_do/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/which_errors_to_handle/screencast/style.css
+++ b/src/epp_topics/software_engineering/which_errors_to_handle/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/software_engineering/writing_simple_pytests/config.py
+++ b/src/epp_topics/software_engineering/writing_simple_pytests/config.py
@@ -2,6 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": ("screencast/public/run_verbose.png",),
+    "other": (),
     "built": ("software_engineering-writing_simple_pytests.pdf",),
 }

--- a/src/epp_topics/software_engineering/writing_simple_pytests/screencast/slides.md
+++ b/src/epp_topics/software_engineering/writing_simple_pytests/screencast/slides.md
@@ -204,7 +204,7 @@ def test_clean_agreement_scale_known_missings():
 
 # Run pytest
 
-<img src="run_verbose.png" class="rounded" width="550"/>
+<img src="/run_verbose.png" class="rounded" width="550"/>
 
 ---
 

--- a/src/epp_topics/software_engineering/writing_simple_pytests/screencast/style.css
+++ b/src/epp_topics/software_engineering/writing_simple_pytests/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/task_export_screencasts.py
+++ b/src/epp_topics/task_export_screencasts.py
@@ -1,6 +1,5 @@
 """Create figure for this subchapter's screencast."""
 
-import shutil
 import subprocess
 from pathlib import Path
 from typing import Annotated
@@ -10,7 +9,7 @@ from pytask import Product, task
 from epp_topics.config import SITE_SOURCE_DIR, SRC
 
 
-def find_orig_screencasts():
+def find_screencasts():
     """Find all files matching screencast pattern, except for template chapter."""
     return [
         sc
@@ -19,30 +18,15 @@ def find_orig_screencasts():
     ]
 
 
-for orig_screencast in find_orig_screencasts():
-    orig_dir = orig_screencast.parent
-    screencast_dir = SITE_SOURCE_DIR / orig_dir.relative_to(SRC)
-    screencast_md = screencast_dir / orig_screencast.name
-
+for screencast_md in find_screencasts():
+    orig_dir = screencast_md.parent
     chapter_name = orig_dir.parent.parent.name
     topic_name = orig_dir.parent.name
-    screencast_pdf = screencast_dir.parent / f"{chapter_name}-{topic_name}.pdf"
-
-    @task(id=f"{chapter_name}, {topic_name}")
-    def task_copy_style_css(
-        orig: Path = SRC / "slidev_config" / "style.css",
-        prod: Annotated[Path, Product] = screencast_dir / "style.css",
-    ):
-        """Copy style.css for slidev presentation."""
-        shutil.copy(orig, prod)
-
-    @task(id=f"{chapter_name}, {topic_name}")
-    def task_copy_slides_md(
-        orig: Path = orig_screencast,
-        prod: Annotated[Path, Product] = screencast_md,
-    ):
-        """Copy slides.md for slidev presentation."""
-        shutil.copy(orig, prod)
+    screencast_pdf = (
+        SITE_SOURCE_DIR
+        / orig_dir.parent.relative_to(SRC)
+        / f"{chapter_name}-{topic_name}.pdf"
+    )
 
     @task(id=f"{chapter_name}, {topic_name}")
     def task_export_pdf(

--- a/src/epp_topics/texts/markdown_applications/screencast/style.css
+++ b/src/epp_topics/texts/markdown_applications/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/texts/markdown_syntax/screencast/style.css
+++ b/src/epp_topics/texts/markdown_syntax/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/texts/markup_languages/screencast/style.css
+++ b/src/epp_topics/texts/markup_languages/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/tools/unix_navigation/config.py
+++ b/src/epp_topics/tools/unix_navigation/config.py
@@ -2,6 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": ("screencast/public/unix_path_mambaforge.png",),
+    "other": (),
     "built": ("tools-unix_navigation.pdf",),
 }

--- a/src/epp_topics/tools/unix_navigation/screencast/slides.md
+++ b/src/epp_topics/tools/unix_navigation/screencast/slides.md
@@ -72,7 +72,7 @@ graph LR
 ### GUI representation
 
 <center>
-<img src="unix_path_mambaforge.png" width=450>
+<img src="/unix_path_mambaforge.png" width=450>
 </center>
 
 ### Shell representation

--- a/src/epp_topics/tools/unix_navigation/screencast/style.css
+++ b/src/epp_topics/tools/unix_navigation/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/tools/why_shells_today/screencast/style.css
+++ b/src/epp_topics/tools/why_shells_today/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css

--- a/src/epp_topics/tools/windows_navigation/config.py
+++ b/src/epp_topics/tools/windows_navigation/config.py
@@ -2,6 +2,6 @@
 
 SITE_CONTENTS = {
     "pages": ("objectives_materials.ipynb",),
-    "other": ("screencast/public/windows_path_mambaforge.png",),
+    "other": (),
     "built": ("tools-windows_navigation.pdf",),
 }

--- a/src/epp_topics/tools/windows_navigation/screencast/slides.md
+++ b/src/epp_topics/tools/windows_navigation/screencast/slides.md
@@ -78,7 +78,7 @@ graph LR
 ### GUI representation
 
 <center>
-<img src="windows_path_mambaforge.png" width=250>
+<img src="/windows_path_mambaforge.png" width=250>
 </center>
 
 

--- a/src/epp_topics/tools/windows_navigation/screencast/style.css
+++ b/src/epp_topics/tools/windows_navigation/screencast/style.css
@@ -1,0 +1,1 @@
+../../../slidev_config/style.css


### PR DESCRIPTION
Also, use `/fig.png` (including the slash) so that figures are actually shown.